### PR TITLE
Error in use statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ composer require magicalex/write-ini-file
 <?php
 require 'vendor/autoload.php';
 
-use \WriteiniFile\WriteiniFile;
+use \WriteIniFile\WriteIniFile;
 
 $data = [
     'fruit' => ['orange' => '100g', 'fraise' => '10g'],


### PR DESCRIPTION
Under the usage section example, the "use \WriteiniFile\WriteiniFile" pointed to an incorrect classpath. Changed to "use \WriteIniFile\WriteIniFile;" according the composer.json autoload.
