### PR TITLE
Escape values with quotes

### DIFF
--- a/src/WriteiniFile.php
+++ b/src/WriteiniFile.php
@@ -141,7 +141,7 @@ class WriteiniFile
             }
         } // @codeCoverageIgnore
 
-        return '"'.$value.'"';
+        return '"'. str_replace('"', '\"', $value) .'"';
     }
 
     /**

--- a/src/WriteiniFile.php
+++ b/src/WriteiniFile.php
@@ -141,7 +141,7 @@ class WriteiniFile
             }
         } // @codeCoverageIgnore
 
-        return '"'. str_replace('"', '\"', $value) .'"';
+	    return '"'.str_replace('"', '\"', $value).'"';
     }
 
     /**

--- a/src/WriteiniFile.php
+++ b/src/WriteiniFile.php
@@ -141,7 +141,7 @@ class WriteiniFile
             }
         } // @codeCoverageIgnore
 
-	    return '"'.str_replace('"', '\"', $value).'"';
+        return '"'.str_replace('"', '\"', $value).'"';
     }
 
     /**

--- a/tests/WriteIniFileTest.php
+++ b/tests/WriteIniFileTest.php
@@ -115,11 +115,11 @@ class WriteIniFileTest extends TestCase
 
     public function testEscapeCharacters()
     {
-    	$actual = 'tests/file_ini/testEscapeCharacters1.ini';
-    	$expected = 'tests/file_ini/testEscapeCharacters2.ini';
+        $actual = 'tests/file_ini/testEscapeCharacters1.ini';
+        $expected = 'tests/file_ini/testEscapeCharacters2.ini';
 
-    	$object = new WriteiniFile($actual);
-    	$object->write();
-    	$this->assertFileEquals($expected, $actual);
+        $object = new WriteiniFile($actual);
+        $object->write();
+        $this->assertFileEquals($expected, $actual);
     }
 }

--- a/tests/WriteIniFileTest.php
+++ b/tests/WriteIniFileTest.php
@@ -115,8 +115,8 @@ class WriteIniFileTest extends TestCase
 
     public function testEscapeCharacters()
     {
-    	$actual = 'file_ini/testEscapeCharacters1.ini';
-    	$expected = 'file_ini/testEscapeCharacters2.ini';
+    	$actual = 'tests/file_ini/testEscapeCharacters1.ini';
+    	$expected = 'tests/file_ini/testEscapeCharacters2.ini';
 
     	$object = new WriteiniFile($actual);
     	$object->write();

--- a/tests/WriteIniFileTest.php
+++ b/tests/WriteIniFileTest.php
@@ -115,8 +115,8 @@ class WriteIniFileTest extends TestCase
 
     public function testEscapeCharacters()
     {
-    	$actual = 'tests/file_ini/testEscapeCharacters1.ini';
-    	$expected = 'tests/file_ini/testEscapeCharacters2.ini';
+    	$actual = 'file_ini/testEscapeCharacters1.ini';
+    	$expected = 'file_ini/testEscapeCharacters2.ini';
 
     	$object = new WriteiniFile($actual);
     	$object->write();

--- a/tests/WriteIniFileTest.php
+++ b/tests/WriteIniFileTest.php
@@ -112,4 +112,14 @@ class WriteIniFileTest extends TestCase
 
         $this->assertFileNotExists($actual);
     }
+
+    public function testEscapeCharacters()
+    {
+    	$actual = 'tests/file_ini/testEscapeCharacters1.ini';
+    	$expected = 'tests/file_ini/testEscapeCharacters2.ini';
+
+    	$object = new WriteiniFile($actual);
+    	$object->write();
+    	$this->assertFileEquals($expected, $actual);
+    }
 }

--- a/tests/file_ini/testEscapeCharacters1.ini
+++ b/tests/file_ini/testEscapeCharacters1.ini
@@ -1,2 +1,3 @@
 [section 1]
-foo = "/usr/bin/example --name=Greg"
+foo = "/usr/bin/example --name=\"Greg's test\" --output=./dist/"
+bar = "Exclamation!question?period."

--- a/tests/file_ini/testEscapeCharacters1.ini
+++ b/tests/file_ini/testEscapeCharacters1.ini
@@ -1,0 +1,2 @@
+[section 1]
+foo = "/usr/bin/example --name=Greg"

--- a/tests/file_ini/testEscapeCharacters2.ini
+++ b/tests/file_ini/testEscapeCharacters2.ini
@@ -1,0 +1,3 @@
+[section 1]
+foo = "/usr/bin/example --name=\"Greg's test\" --output=./dist/"
+bar = "Exclamation!question?period."


### PR DESCRIPTION
Strings with quotes are now escaped with a backslash. This fixes #7 .